### PR TITLE
Implemented optional palette overwrites for DEF unpacking

### DIFF
--- a/lib/unpackDEF.js
+++ b/lib/unpackDEF.js
@@ -17,22 +17,17 @@ function unpackDEF(buffer, options = {}) {
    if (options.padding === undefined)
       options.padding = false
 
+   if (options.palette === undefined)
+      options.palette = (colors) => colors
+
    if (options.format !== "png" && options.format !== "bitmap")
       throw new Error("DEF output format not supported.")
 
    if (options.padding !== true && options.padding !== false)
       throw new Error("Padding must be a boolean.")
 
-   if (options.paletteOverwrite) {
-      if (!Number.isInteger(options.paletteOverwrite.offset)
-         || options.paletteOverwrite.offset < 0
-         || options.paletteOverwrite.offset >= 256)
-         throw new Error("Offset must be an integer between 0 and 255.")
-
-      if (!Array.isArray(options.paletteOverwrite.colors)
-         || options.paletteOverwrite.colors.length + options.paletteOverwrite.offset > 256)
-         throw new Error("Colors must be an array of rgba colors and not exceed the length of the DEF palette when applied.")
-   }
+   if (typeof options.palette !== 'function')
+      throw new Error("Palette must be a function.")
 
    // Header.
    const type = defineFileType(buffer.uint32())
@@ -40,7 +35,7 @@ function unpackDEF(buffer, options = {}) {
    const fullHeight = buffer.uint32()
 
    const groupCount = buffer.uint32()
-   const palette = buffer.loop(256, () => ({ r: buffer.uint8(), g: buffer.uint8(), b: buffer.uint8(), a: 255 }))
+   let palette = buffer.loop(256, () => ({ r: buffer.uint8(), g: buffer.uint8(), b: buffer.uint8(), a: 255 }))
 
    // Replace special colors in palette.
    palette[0] = { r: 0, g: 0, b: 0, a: 0 }    // Transparency                 (0,255,255)
@@ -50,13 +45,9 @@ function unpackDEF(buffer, options = {}) {
    palette[6] = { r: 0, g: 0, b: 0, a: 128 }  // Selection over shadow body   (180,0,255)
    palette[7] = { r: 0, g: 0, b: 0, a: 64 }   // Selection over shadow border (0,255,0)
 
+   // Apply palette processor function.
+   palette = options.palette(palette)
    options.palette = palette
-
-   if (options.paletteOverwrite) {
-      for (let i = 0; i < options.paletteOverwrite.colors.length; i++) {
-         options.palette[options.paletteOverwrite.offset + i] = options.paletteOverwrite.colors[i]
-      }
-   }
 
    // After the header, a sequence of animation groups follows. Each contains pointers to the actual images, which
    // are immediately parsed and stored in `images`.

--- a/lib/unpackDEF.js
+++ b/lib/unpackDEF.js
@@ -23,6 +23,16 @@ function unpackDEF(buffer, options = {}) {
    if (options.padding !== true && options.padding !== false)
       throw new Error("Padding must be a boolean.")
 
+   if (options.paletteOverwrite) {
+      if (!Number.isInteger(options.paletteOverwrite.offset)
+         || options.paletteOverwrite.offset < 0
+         || options.paletteOverwrite.offset >= 256)
+         throw new Error("Offset must be an integer between 0 and 255.")
+
+      if (!Array.isArray(options.paletteOverwrite.colors)
+         || options.paletteOverwrite.colors.length + options.paletteOverwrite.offset > 256)
+         throw new Error("Colors must be an array of rgba colors and not exceed the length of the DEF palette when applied.")
+   }
 
    // Header.
    const type = defineFileType(buffer.uint32())
@@ -41,6 +51,12 @@ function unpackDEF(buffer, options = {}) {
    palette[7] = { r: 0, g: 0, b: 0, a: 64 }   // Selection over shadow border (0,255,0)
 
    options.palette = palette
+
+   if (options.paletteOverwrite) {
+      for (let i = 0; i < options.paletteOverwrite.colors.length; i++) {
+         options.palette[options.paletteOverwrite.offset + i] = options.paletteOverwrite.colors[i]
+      }
+   }
 
    // After the header, a sequence of animation groups follows. Each contains pointers to the actual images, which
    // are immediately parsed and stored in `images`.


### PR DESCRIPTION
Some DEFs are intended to be colored in player colors. This works by replacing the last 32 colors in the palette with the corresponding colors from players.pal file.

From what I've seen, there is currently no way to do that with this unpacker. This simple implementation lets the user replace an arbitrary range of colors within the DEF's palette.